### PR TITLE
error with deriving end intervals fixed

### DIFF
--- a/lowstate_selection.ipynb
+++ b/lowstate_selection.ipynb
@@ -9792,7 +9792,7 @@
     "        start_idx = 0\n",
     "    else:\n",
     "        start_idx = 1\n",
-    "    intervalends = np.nonzero(np.diff(mask) == True)[0]\n",
+    "    intervalends = np.nonzero(np.diff(mask) != 0)[0]\n",
     "    intervalends = [-1] + list(intervalends) + [len(mask)-1]\n",
     "    return [\n",
     "        (intervalends[i]+1, intervalends[i+1]+1)\n",
@@ -9823,7 +9823,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -9837,7 +9837,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Now function intervals_from_mask really does what is expected, i.e., e.g., [0, 0, 0, 1, 1, 1, 0, 0, 1, 0, 0, 1, 1] -> [(3,6), (8,9), (11,13)]